### PR TITLE
Update Spotify client ID and fix auth CLI

### DIFF
--- a/.changeset/update-spotify-client.md
+++ b/.changeset/update-spotify-client.md
@@ -1,0 +1,5 @@
+---
+"dj-claude": patch
+---
+
+Update Spotify client ID and make auth CLI directly executable

--- a/src/auth/cli.ts
+++ b/src/auth/cli.ts
@@ -86,3 +86,9 @@ export async function runAuth() {
   console.error("\nTokens saved to ~/.dj-claude/tokens.json");
   console.error("Auth setup complete!");
 }
+
+// Run when executed directly
+runAuth().catch((err) => {
+  console.error(`\nAuth failed: ${err.message}`);
+  process.exit(1);
+});

--- a/src/auth/spotify-auth.ts
+++ b/src/auth/spotify-auth.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 
 const TOKEN_ENDPOINT = "https://accounts.spotify.com/api/token";
 
-export const CLIENT_ID = "20273f2d8f8a4e42be633e0ff498cdca";
+export const CLIENT_ID = "53967543970545da9be299df52e94005";
 
 export const SCOPES = [
   "user-read-playback-state",


### PR DESCRIPTION
## Summary

- Update Spotify OAuth client ID
- Make auth CLI (`src/auth/cli.ts`) directly executable by adding a top-level `runAuth()` call with error handling

## Test plan

- [ ] Run `bun run auth` → verify OAuth flow completes with new client ID
- [ ] Run `bun run src/auth/cli.ts` directly → verify it works as a standalone script