### PR TITLE
Change OAuth callback port to avoid conflicts

### DIFF
--- a/.changeset/auth-callback-port.md
+++ b/.changeset/auth-callback-port.md
@@ -1,0 +1,5 @@
+---
+"dj-claude": patch
+---
+
+Change OAuth callback port from 8888 to 45981 to avoid conflicts

--- a/src/auth/cli.ts
+++ b/src/auth/cli.ts
@@ -7,7 +7,7 @@ import {
 } from "./spotify-auth.js";
 import { saveTokens } from "./token-store.js";
 
-const REDIRECT_URI = "http://127.0.0.1:8888/callback";
+const REDIRECT_URI = "http://127.0.0.1:45981/callback";
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export async function runAuth() {
@@ -35,7 +35,7 @@ export async function runAuth() {
     }, AUTH_TIMEOUT_MS);
 
     httpServer = Bun.serve({
-      port: 8888,
+      port: 45981,
       hostname: "127.0.0.1",
       fetch(req) {
         const url = new URL(req.url);
@@ -70,7 +70,7 @@ export async function runAuth() {
       },
     });
 
-    console.error("Waiting for authorization callback on port 8888...");
+    console.error("Waiting for authorization callback on port 45981...");
   });
 
   console.error("\nExchanging code for tokens...");


### PR DESCRIPTION
## Summary

- Change OAuth callback port from 8888 to 45981
- Port 8888 is commonly used by Jupyter and other tools, causing potential conflicts during auth setup

## Test plan

- [ ] Run `bun run auth` → verify callback server starts on port 45981
- [x] Complete OAuth flow → verify redirect to `127.0.0.1:45981/callback` works
- [x] Update Spotify app dashboard redirect URI to match new port