### PR TITLE
Fix auth callback server not releasing port

### DIFF
--- a/.changeset/fix-auth-server-stop.md
+++ b/.changeset/fix-auth-server-stop.md
@@ -1,0 +1,5 @@
+---
+"dj-claude": patch
+---
+
+Force-close auth callback server to prevent EADDRINUSE on subsequent runs

--- a/src/auth/cli.ts
+++ b/src/auth/cli.ts
@@ -30,7 +30,7 @@ export async function runAuth() {
     let httpServer: ReturnType<typeof Bun.serve>;
 
     const timeout = setTimeout(() => {
-      httpServer?.stop();
+      httpServer?.stop(true);
       reject(new Error("Authorization timed out after 5 minutes. Please try again."));
     }, AUTH_TIMEOUT_MS);
 
@@ -47,7 +47,7 @@ export async function runAuth() {
         const error = url.searchParams.get("error");
         if (error) {
           clearTimeout(timeout);
-          httpServer.stop();
+          httpServer.stop(true);
           reject(new Error(`Authorization failed: ${error}`));
           return new Response(`Authorization failed: ${error}`, { status: 400 });
         }
@@ -55,7 +55,7 @@ export async function runAuth() {
         const authCode = url.searchParams.get("code");
         if (!authCode) {
           clearTimeout(timeout);
-          httpServer.stop();
+          httpServer.stop(true);
           reject(new Error("Missing authorization code"));
           return new Response("Missing authorization code", { status: 400 });
         }


### PR DESCRIPTION
## Summary

- Pass `true` to `Bun.serve.stop()` to force-close all connections immediately
- Without this, the port stays bound after auth completes, causing `EADDRINUSE` on subsequent runs

## Test plan

- [ ] Run `bun run auth` twice in a row → verify no `EADDRINUSE` error on second run