### PR TITLE
Fix auth running twice in compiled binary

### DIFF
--- a/.changeset/fix-auth-double-run.md
+++ b/.changeset/fix-auth-double-run.md
@@ -1,0 +1,5 @@
+---
+"dj-claude": patch
+---
+
+Guard top-level runAuth() with import.meta.main to prevent double execution in binary

--- a/src/auth/cli.ts
+++ b/src/auth/cli.ts
@@ -87,8 +87,10 @@ export async function runAuth() {
   console.error("Auth setup complete!");
 }
 
-// Run when executed directly
-runAuth().catch((err) => {
-  console.error(`\nAuth failed: ${err.message}`);
-  process.exit(1);
-});
+// Run when executed directly (bun run src/auth/cli.ts)
+if (import.meta.main) {
+  runAuth().catch((err) => {
+    console.error(`\nAuth failed: ${err.message}`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- Guard top-level `runAuth()` call with `import.meta.main` check
- When running `dj-claude auth`, `index.ts` imports `cli.ts` then calls `runAuth()` — but the unconditional top-level call in `cli.ts` also fires, starting two servers on the same port
- `import.meta.main` is only `true` when `cli.ts` is the direct entry point (`bun run src/auth/cli.ts`), not when imported

## Test plan

- [x] Run `dj-claude auth` (compiled binary) → verify no EADDRINUSE error
- [x] Run `bun run auth` (dev mode) → verify auth still works