### PR TITLE
Allow custom Spotify client ID via env var

### DIFF
--- a/.changeset/custom-spotify-client-id.md
+++ b/.changeset/custom-spotify-client-id.md
@@ -1,0 +1,5 @@
+---
+"dj-claude": minor
+---
+
+Allow overriding the Spotify client ID via SPOTIFY_CLIENT_ID environment variable.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ dj-claude auth                      # Log in with Spotify
 claude mcp add dj-claude -- dj-claude  # Register as MCP server
 ```
 
+### Using your own Spotify app
+
+By default dj-claude uses a shared Spotify client ID. To use your own:
+
+1. Create an app at [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
+2. Set the redirect URI to `http://127.0.0.1:45981/callback`
+3. Set the `SPOTIFY_CLIENT_ID` environment variable before running auth:
+
+```sh
+SPOTIFY_CLIENT_ID=your_client_id dj-claude auth
+```
+
+To pass it through when running as an MCP server:
+
+```sh
+claude mcp add dj-claude -e SPOTIFY_CLIENT_ID=your_client_id -- dj-claude
+```
+
 ## Examples
 
 Once set up, just talk to Claude:

--- a/src/auth/spotify-auth.ts
+++ b/src/auth/spotify-auth.ts
@@ -2,7 +2,8 @@ import { createHash, randomBytes } from "node:crypto";
 
 const TOKEN_ENDPOINT = "https://accounts.spotify.com/api/token";
 
-export const CLIENT_ID = "53967543970545da9be299df52e94005";
+const DEFAULT_CLIENT_ID = "53967543970545da9be299df52e94005";
+export const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID || DEFAULT_CLIENT_ID;
 
 export const SCOPES = [
   "user-read-playback-state",

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -2,8 +2,6 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { z } from "zod";
-import { CLIENT_ID } from "./spotify-auth.js";
-
 const StoredTokensSchema = z.object({
   clientId: z.string(),
   accessToken: z.string(),
@@ -39,8 +37,6 @@ export async function getTokens(): Promise<StoredTokens> {
     throw new Error(`Invalid token file (${TOKEN_PATH}). Delete it and re-run \`dj-claude auth\`.`);
   }
 
-  // Always use the hardcoded client ID
-  result.data.clientId = CLIENT_ID;
   return result.data;
 }
 


### PR DESCRIPTION
## Summary

- Read `SPOTIFY_CLIENT_ID` env var with fallback to the default client ID
- Remove hardcoded client ID override in token store so the stored client ID (from auth time) is used for token refresh
- Add "Using your own Spotify app" section to README with setup instructions

## Details

Users can now bring their own Spotify app instead of needing to be added to the shared one. Set `SPOTIFY_CLIENT_ID` before running `dj-claude auth`, and pass it via `-e` when registering the MCP server.