### PR TITLE
Fix CI checks not running on changesets PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,9 @@ jobs:
         id: changesets
         with:
           version: bunx @changesets/cli version
+          commitMode: github-api
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
 
       - name: Check if release needed
         if: steps.changesets.outputs.hasChangesets == 'false'


### PR DESCRIPTION
## Summary

- Use `RELEASE_PAT` instead of `GITHUB_TOKEN` in the changesets action so pushes to `changeset-release/main` trigger CI workflows
- Set `commitMode: github-api` so commits are attributed to the PAT owner (required for workflow triggering)

## Context

Pushes made with `GITHUB_TOKEN` don't trigger other workflows ([GitHub docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow), [changesets/action#523](https://github.com/changesets/action/issues/523)). This meant CI checks never ran on the "Version Packages" PR.

## Setup

Requires a `RELEASE_PAT` fine-grained PAT repo secret with Contents and Pull requests read/write permissions.